### PR TITLE
Enable test runner

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,9 +4,12 @@
   "active": false,
   "status": {
     "concept_exercises": false,
-    "test_runner": false,
+    "test_runner": true,
     "representer": false,
     "analyzer": false
+  },
+  "test_runner": {
+    "average_run_time": 1
   },
   "blurb": "YAMLScript is a dynamic, general purpose programming language. It has a clean YAML syntax and embeds nicely into existing YAML files, making the desired parts of them dynamic. When a YAMLScript program is run, the source code transpiles to Clojure code, and is evaluted by a native binary runtime interpreter called `ys` (not by the JVM). YAMLScript is also available as a dynamic YAML loader library",
   "version": 3,

--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,12 @@ active: false
 
 status:
   concept_exercises: false
-  test_runner: false
+  test_runner: true
   representer: false
   analyzer: false
+
+test_runner:
+  average_run_time: 1
 
 blurb:
   YAMLScript is a dynamic, general purpose programming language.


### PR DESCRIPTION
I believe the test runner should be up and running.

Docker file is on Docker hub: https://hub.docker.com/r/exercism/yamlscript-test-runner

Relevant comment: http://forum.exercism.org/t/yamlscript-language-track/11862/82

I have done no benchmarking on the number of seconds for running tests, but it can be tweaked later.